### PR TITLE
Remove references to index and README for proper linking on GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dynamically selecting the image(s), application(s), and configuration(s) to be
 applied to a host. It retrieves any required files over the network, executes
 scripts and binaries, and modifies the host as required.
 
-Want to dive right in? See [here](doc/README.md) for further Glazier documentation.
+Want to dive right in? See [here](doc) for further Glazier documentation.
 
 ## Why Glazier?
 
@@ -54,12 +54,12 @@ Glazier makes it simple to extend the installer by writing a bit of Python or
 PowerShell code. See creating new actions under docs to get started.
 
 Glazier's Actions are the core of the system's configuration language. Glazier
-ships with some [existing actions](glazier/lib/actions/README.md), but for more
+ships with some [existing actions](glazier/lib/actions), but for more
 custom functionality, you can also create your own.
 
 ## Where do I start?
 
-We recommend starting with [these docs](doc/README.md) to learn about how Glazier works under the hood.
+We recommend starting with [these docs](doc) to learn about how Glazier works under the hood.
 
 ## Contact
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,8 +10,8 @@ See the links below to help get you started with your own Glazier configuration.
 
 *   [About Glazier](./setup/about.md) - Basic operating principles used in
     Glazier.
-*   [Setup Guide](./setup/README.md) - Getting started with the basic principles
-    from the about page.
+*   [Setup Guide](./setup) - Getting started with the basic principles from the
+    about page.
 
 ## Glazier Configurations
 
@@ -27,8 +27,8 @@ supported syntax.
 
 ## YAML Files
 
-*   [Glazier YAML File Specs](./yaml/README.md) - Glazier uses YAML-based
-    configuration files. These documents outline the supported syntax.
+*   [Glazier YAML File Specs](./yaml) - Glazier uses YAML-based configuration
+    files. These documents outline the supported syntax.
 *   [Chooser Interface Configs](./yaml/chooser_ui.md) - The Chooser setup UI is
     an enhancement to autobuild which allows Glazier to present the user with a
     dynamic list of options as part of the installation process.
@@ -37,11 +37,10 @@ supported syntax.
 
 ## Python
 
-*   [Installer Actions](../glazier/lib/actions/README.md) - Actions are classes which
-    the configuration handler may call to perform a variety of tasks during
-    imaging.
-*   [Policy Modules](../glazier/lib/policies/README.md) - Policy modules determine
-    whether or not Autobuild should be allowed to proceed with an installation.
+*   [Installer Actions](../glazier/lib/actions) - Actions are classes which the
+    configuration handler may call to perform a variety of tasks during imaging.
+*   [Policy Modules](../glazier/lib/policies) - Policy modules determine whether or not
+    Autobuild should be allowed to proceed with an installation.
 *   [Config Handlers](./setup/config_handlers.md) - The Glazier configuration
     handling libraries are responsible for taking the configuration language as
     input, determining which commands apply to the current system, and executing

--- a/doc/setup/README.md
+++ b/doc/setup/README.md
@@ -199,4 +199,4 @@ and `applications/build.yaml` files (for illustration - not shown here).
 Finally, the host would reboot.
 
 More information about configuration files is available in the
-[Glazier Build YAML Specification](../yaml/README.md).
+[Glazier Build YAML Specification](../yaml).

--- a/doc/setup/about.md
+++ b/doc/setup/about.md
@@ -121,8 +121,8 @@ to branch into different configurations once you have a working foundation.
 
 ## Configuration Files
 
-The [Glazier Build YAML Specification](../yaml/README.md) page goes into detail
-about the format of Glazier's configuration files.
+The [Glazier Build YAML Specification](../yaml) page goes into detail about the
+format of Glazier's configuration files.
 
 "Text files" may seem like a surprising foundation for an imaging system,
 however they are ultimately one of the most powerful and flexible options
@@ -225,7 +225,7 @@ Python, you can easily extend Glazier with custom functionality.
 
 When it comes to the act of imaging a system, most of Glazier's time is spent
 performing Actions. Glazier ships with a number of core Actions, which are
-documented in [the Actions README](../../glazier/lib/actions/README.md).
+documented in [the Actions README](../../glazier/lib/actions).
 
 The Actions module in Glazier was created to be as easy to extend as possible.
 Actions are automatically recognized by Autobuild's configuration handler. An


### PR DESCRIPTION
Remove references to index and README for proper linking on GitHub.