### PR TITLE
Output sensible error messages in Glazier when URL's aren't returned

### DIFF
--- a/glazier/lib/download.py
+++ b/glazier/lib/download.py
@@ -174,6 +174,12 @@ class BaseDownloader(object):
     for handler in self._GetHandlers():
       opener.add_handler(handler)
     urllib.request.install_opener(opener)
+
+    url = url.strip()
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.netloc:
+      raise DownloadError('Invalid remote server URL "%s".' % url)
+
     while True:
       try:
         attempt += 1

--- a/glazier/lib/download_test.py
+++ b/glazier/lib/download_test.py
@@ -103,26 +103,26 @@ class DownloadTest(absltest.TestCase):
   def testOpenStreamInternal(self, sleep, urlopen):
     file_stream = mock.Mock()
     file_stream.getcode.return_value = 200
+    url = 'https://www.example.com/build.yaml'
     httperr = download.urllib.error.HTTPError('Error', None, None, None, None)
     urlerr = download.urllib.error.URLError('Error')
     # 200
     urlopen.side_effect = iter([httperr, urlerr, file_stream])
-    res = self._dl._OpenStream(
-        'https://www.example.com/build.yaml', max_retries=4)
+    res = self._dl._OpenStream(url, max_retries=4)
     self.assertEqual(res, file_stream)
+    # Invalid URL
+    with self.assertRaisesRegex(download.DownloadError,
+                                'Invalid remote server URL*'):
+      self._dl._OpenStream('not_a_real_url', max_retries=0)
     # 404
     file_stream.getcode.return_value = 404
     urlopen.side_effect = iter([httperr, file_stream])
-    self.assertRaises(download.DownloadError, self._dl._OpenStream,
-                      'https://www.example.com/build.yaml')
+    self.assertRaises(download.DownloadError, self._dl._OpenStream, url)
     # retries
     file_stream.getcode.return_value = 200
     urlopen.side_effect = iter([httperr, httperr, file_stream])
-    self.assertRaises(
-        download.DownloadError,
-        self._dl._OpenStream,
-        'https://www.example.com/build.yaml',
-        max_retries=2)
+    self.assertRaises(download.DownloadError, self._dl._OpenStream, url,
+                      max_retries=2)
     sleep.assert_has_calls([mock.call(20), mock.call(20)])
 
   @mock.patch.object(download.urllib.request, 'urlopen', autospec=True)


### PR DESCRIPTION
Output sensible error messages in Glazier when URL's aren't returned