### PR TITLE
Move verify_urls into constants so we can reuse the same values

### DIFF
--- a/glazier/lib/config/runner.py
+++ b/glazier/lib/config/runner.py
@@ -18,19 +18,12 @@ from __future__ import print_function
 
 import sys
 
-from absl import flags
-
+from glazier.lib import constants
 from glazier.lib import download
 from glazier.lib import policies
 from glazier.lib import power
 from glazier.lib.config import base
 from glazier.lib.config import files
-
-FLAGS = flags.FLAGS
-flags.DEFINE_list(
-    'verify_urls',
-    [],
-    'Comma-separated list of URLs to verify are reachable at start')
 
 
 class ConfigRunnerError(base.ConfigError):
@@ -65,9 +58,9 @@ class ConfigRunner(base.ConfigBase):
     Raises:
       ConfigRunnerError: failure to confirm verify_urls
     """
-    if FLAGS.verify_urls:
+    if constants.FLAGS.verify_urls:
       dl = download.Download()
-      for url in FLAGS.verify_urls:
+      for url in constants.FLAGS.verify_urls:
         if not dl.CheckUrl(url, [200], max_retries=-1):
           raise ConfigRunnerError('verify_urls failed for url %s' % url)
 

--- a/glazier/lib/config/runner_test.py
+++ b/glazier/lib/config/runner_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 from pyfakefs import fake_filesystem
 from pyfakefs import fake_filesystem_shutil
 from glazier.lib import buildinfo
+from glazier.lib import constants
 from glazier.lib.config import runner
 
 import mock
@@ -28,7 +29,7 @@ class ConfigRunnerTest(absltest.TestCase):
   def setUp(self):
     super(ConfigRunnerTest, self).setUp()
     self.buildinfo = buildinfo.BuildInfo()
-    runner.FLAGS.verify_urls = None
+    constants.FLAGS.verify_urls = None
     # filesystem
     self.filesystem = fake_filesystem.FakeFilesystem()
     runner.os = fake_filesystem.FakeOsModule(self.filesystem)
@@ -133,7 +134,7 @@ class ConfigRunnerTest(absltest.TestCase):
   @mock.patch.object(runner.download.Download, 'CheckUrl', autospec=True)
   def testVerifyUrls(self, dl):
     dl.return_value = True
-    runner.FLAGS.verify_urls = ['http://www.example.com/']
+    constants.FLAGS.verify_urls = ['http://www.example.com/']
     self.cr._ProcessTasks([])
     dl.assert_called_with(
         mock.ANY, 'http://www.example.com/', [200], max_retries=-1)

--- a/glazier/lib/constants.py
+++ b/glazier/lib/constants.py
@@ -61,3 +61,7 @@ flags.DEFINE_enum('environment', 'Host', ['Host', 'WinPE'],
                   'The running host environment.')
 flags.DEFINE_string('ntp_server', 'time.google.com',
                     'Server to use for synchronizing the local system time.')
+flags.DEFINE_list(
+    'verify_urls',
+    [],
+    'Comma-separated list of URLs to verify are reachable at start')


### PR DESCRIPTION
Move verify_urls into constants so we can reuse the same values
Adjust unit tests accordingly