### PR TITLE
Drop test support for Python 2.7 due to EOL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
 python:
-  - '2.7'
   - '3.6'
+  - '3.7'
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Drop test support for Python 2.7 due to EOL.
