### PR TITLE
Use registry as the definitive source for winpe detection instead of a Glazier flag.

### DIFF
--- a/glazier/autobuild.py
+++ b/glazier/autobuild.py
@@ -51,9 +51,9 @@ class AutoBuild(object):
 
   def _SetupTaskList(self):
     """Determines the location of the task list and erases if necessary."""
-    location = constants.WINPE_TASK_LIST
-    if FLAGS.environment == 'Host':
-      location = constants.SYS_TASK_LIST
+    location = constants.SYS_TASK_LIST
+    if self._build_info.CheckWinPE():
+      location = constants.WINPE_TASK_LIST
     logging.debug('Using task list at %s', location)
     if not FLAGS.preserve_tasks and os.path.exists(location):
       logging.debug('Purging old task list.')

--- a/glazier/lib/constants.py
+++ b/glazier/lib/constants.py
@@ -51,7 +51,7 @@ WINPE_GOOGETROOT = '%s\\ProgramData\\GooGet' % WINPE_ROOT
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('binary_root_path', '/bin', 'Path to the binary storage.')
-flags.DEFINE_string('config_root_path', '/autobuild',
+flags.DEFINE_string('config_root_path', '',
                     'Path to the root of the configuration directory.')
 flags.DEFINE_string('config_server', 'https://glazier-server.example.com',
                     'Root URL for all build data.')


### PR DESCRIPTION
Use registry as the definitive source for winpe detection instead of a Glazier flag.

* Add intermediary folders if config_root_path is defined.
* Change defaults for config_root_path
