### PR TITLE
set default for config_root_path

### DIFF
--- a/glazier/lib/constants.py
+++ b/glazier/lib/constants.py
@@ -62,7 +62,7 @@ flags.DEFINE_string('binary_root_path', '/bin', 'Path to the binary storage.')
 flags.DEFINE_string('binary_server', '', 'Root URL for binary build files.')
 flags.DEFINE_boolean('config_branches', True,
                      'The configuration repository uses branched paths.')
-flags.DEFINE_string('config_root_path', '',
+flags.DEFINE_string('config_root_path', 'config',
                     'Path to the root of the configuration directory.')
 flags.DEFINE_string('config_server', 'https://glazier-server.example.com',
                     'Root URL for configuration build data.')


### PR DESCRIPTION
https://github.com/google/glazier/blob/master/docs/setup/config_layout.md#components implies that Glazier will look for the first `build.yaml` file under `config_server/$branch/config/build.yaml` but `config_root_path` is, by default, set to `''` so Glazier will try and fail to find `config_server/$branch/build.yaml`. 

This PR makes the code match the docs :)