### PR TITLE
add pywin32 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pyfakefs
 PyYAML
 requests
 six
+pywin32
 git+git://github.com/google/winops@master#egg=gwinpy


### PR DESCRIPTION
The Glazier docs say that pywin32 is optional but I feel like most users would want it? Let me know what you think.