### PR TITLE
Update actions.md: correct UpdateMSU options

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -774,6 +774,16 @@ Process updates in MSU format. Downloads file, verifies hash, creates a
 SYS_CACHE\Updates folder that is used as a temp location to extract the msu
 file, and applies the update to the base image.
 
+#### Arguments
+
+*   Format: List
+    *   Arg1[list]: First update to apply
+        *   ArgA[str]: Update path (can be a full HTTP(s) URL)
+        *   ArgB[str]: Local download location.
+        *   ArgC[str]: SHA256 hash
+    *   Arg2[list]: Second update to apply (Optional)
+    *   ...
+
 #### Examples
 
 ```yaml

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -778,7 +778,11 @@ file, and applies the update to the base image.
 
 ```yaml
 UpdateMSU: [
-  ['@/Driver/HP/z840/win7/20160909/kb290292.msu', 'C:\Glazier_Cache\kb290292.msu', 'cd8f4222a9ba4c4493d8df208fe38cdad969514512d6f5dfd0f7cc7e1ea2c782']
+  [
+    '@/Driver/HP/z840/win7/20160909/kb290292.msu',
+    'C:\Glazier_Cache\kb290292.msu',
+    'cd8f4222a9ba4c4493d8df208fe38cdad969514512d6f5dfd0f7cc7e1ea2c782'
+  ]
 ]
 ```
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -777,9 +777,9 @@ file, and applies the update to the base image.
 #### Examples
 
 ```yaml
-Update: ['@/Driver/HP/z840/win7/20160909/kb290292.msu',
-         'C:\Glazier_Cache\kb290292.msu',
-         'cd8f4222a9ba4c4493d8df208fe38cdad969514512d6f5dfd0f7cc7e1ea2c782']
+UpdateMSU: [
+  ['@/Driver/HP/z840/win7/20160909/kb290292.msu', 'C:\Glazier_Cache\kb290292.msu', 'cd8f4222a9ba4c4493d8df208fe38cdad969514512d6f5dfd0f7cc7e1ea2c782']
+]
 ```
 
 ### Warn


### PR DESCRIPTION
The example for `UpdateMSU` in the docs is misleading.

The option need to be an array of updates, each itself an array of arguments.