### PR TITLE
Implement read/connect timeout for file downloads

### DIFF
--- a/glazier/lib/download.py
+++ b/glazier/lib/download.py
@@ -49,6 +49,8 @@ SLEEP = 20
 # Maximum amount of time to spend on all backoff retries, in seconds.
 BACKOFF_MAX_TIME = 600
 
+# Timeout for all blocking operations with urllib (connect, read, etc).
+TIMEOUT=60
 
 class Error(errors.GlazierError):
   pass
@@ -282,9 +284,9 @@ class BaseDownloader(object):
 
     try:
       if winpe.check_winpe():
-        file_stream = urllib.request.urlopen(url, cafile=self._ca_cert_file)
+        file_stream = urllib.request.urlopen(url, timeout=TIMEOUT, cafile=self._ca_cert_file)
       else:
-        file_stream = urllib.request.urlopen(url)
+        file_stream = urllib.request.urlopen(url, timeout=TIMEOUT)
 
     # First attempt failed with HTTPError. Reraise and trigger a retry.
     except urllib.error.HTTPError:


### PR DESCRIPTION
As discussed in #723 , implement a global timeout for blocking operations in the urllib connection used for downloading files.

After having done further research, this does affect socket read operations once the connection is open, not just the initial connection establishment - I wanted to double check this, as I'd initially seen some conflicting information.

60 seconds feels like a safe timeout, although I'm open to making this higher if you feel necessary.