### PR TITLE
Fix Python test suite failures on Windows.

### DIFF
--- a/glazier/lib/actions/installer_test.py
+++ b/glazier/lib/actions/installer_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for glazier.lib.actions.installer."""
 
+import os
 from unittest import mock
 
 from absl.testing import absltest
@@ -126,7 +127,7 @@ class InstallerTest(test_utils.GlazierTestCase):
     d = installer.BuildInfoDump(None, mock_buildinfo)
     d.Run()
     mock_buildinfo.Serialize.assert_called_with(
-        '{}/build_info.yaml'.format(constants.SYS_CACHE))
+        os.path.join(constants.SYS_CACHE, 'build_info.yaml'))
 
   @mock.patch.object(installer.registry, 'set_value', autospec=True)
   @mock.patch.object(buildinfo, 'BuildInfo', autospec=True)
@@ -157,7 +158,7 @@ class InstallerTest(test_utils.GlazierTestCase):
     installer.BuildInfoSave(None, mock_buildinfo).Run()
     mock_debug.assert_called_with(
         '%s does not exist - skipped processing.',
-        '{}/build_info.yaml'.format(constants.SYS_CACHE))
+        os.path.join(constants.SYS_CACHE, 'build_info.yaml'))
 
   def test_change_server(self):
     build_info = buildinfo.BuildInfo()
@@ -170,13 +171,12 @@ class InstallerTest(test_utils.GlazierTestCase):
 
   @mock.patch.object(installer.file_system, 'CopyFile', autospec=True)
   def test_exit_win_pe(self, mock_copyfile):
-    cache = constants.SYS_CACHE
     ex = installer.ExitWinPE(None, None)
     with self.assert_raises_with_validation(events.RestartEvent):
       ex.Run()
     mock_copyfile.assert_has_calls([
-        mock.call(['/task_list.yaml',
-                   '%s/task_list.yaml' % cache], mock.ANY),
+        mock.call([constants.WINPE_TASK_LIST,
+                   constants.SYS_TASK_LIST], mock.ANY),
     ])
     mock_copyfile.return_value.Run.assert_called()
 

--- a/glazier/lib/cache_test.py
+++ b/glazier/lib/cache_test.py
@@ -74,7 +74,7 @@ class CacheTest(test_utils.GlazierTestCase):
     path = self.cache._DestinationPath(
         'C:', 'http://some.web.address/folder/other/'
         'an_installer.msi')
-    self.assertEqual(path, os.path.join('C:', 'an_installer.msi'))
+    self.assertEqual(path, os.path.join('C:' + os.sep, 'an_installer.msi'))
 
   def test_find_download(self):
     line_test = self.cache._FindDownload('powershell -file '

--- a/glazier/lib/download_test.py
+++ b/glazier/lib/download_test.py
@@ -122,8 +122,13 @@ class DownloadTest(test_utils.GlazierTestCase):
     super(DownloadTest, self).setUp()
     self._dl = download.BaseDownloader()
 
+    # Written as bytes, not str: absltest's create_tempfile() opens a str
+    # `content` in text mode, so on Windows the '\n' in _TEST_INI would be
+    # translated to '\r\n' on disk and the hardcoded SHA256 below would no
+    # longer match. Bytes content is written via write_bytes(), with no
+    # newline translation, on every platform.
     self.input_ini_path = self.create_tempfile(
-        file_path='input.ini', content=_TEST_INI)
+        file_path='input.ini', content=_TEST_INI.encode('utf-8'))
 
     # Very important, unless you want tests that fail indefinitely to backoff
     # for 10 minutes.

--- a/glazier/lib/logs_test.py
+++ b/glazier/lib/logs_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for glazier.lib.logs."""
 
+import os
 from unittest import mock
 import zipfile
 
@@ -49,8 +50,11 @@ class LoggingTest(test_utils.GlazierTestCase):
     zip_path = self.create_tempfile(file_path='glazier.zip').full_path
     logs.Collect(zip_path)
 
+    # zipfile.write() derives the archive name by stripping any drive letter
+    # and leading path separators, then normalizing to '/'.
+    arcname = os.path.splitdrive(files[1])[1].replace(os.sep, '/').lstrip('/')
     with zipfile.ZipFile(zip_path, 'r') as out:
-      with out.open(files[1].lstrip('/')) as f2:
+      with out.open(arcname) as f2:
         self.assertEqual(f2.read(), b'log2 content')
 
   def test_collect_io_err(self):

--- a/glazier/lib/ntp_test.py
+++ b/glazier/lib/ntp_test.py
@@ -27,13 +27,12 @@ from glazier.lib import test_utils
 
 class NtpTest(test_utils.GlazierTestCase):
 
+  @mock.patch.object(ntp.time, 'localtime', side_effect=time.gmtime)
   @mock.patch.object(ntp.time, 'sleep', autospec=True)
   @mock.patch.object(execute, 'execute_binary', autospec=True)
   @mock.patch.object(ntp.ntplib.NTPClient, 'request', autospec=True)
-  def test_sync_clock_to_ntp(self, request, eb, sleep):
+  def test_sync_clock_to_ntp(self, request, eb, sleep, unused_localtime):
 
-    os.environ['TZ'] = 'UTC'
-    time.tzset()
     return_time = mock.Mock()
     return_time.ref_time = 1453220630.64458
     request.side_effect = iter([None, None, None, return_time])
@@ -49,10 +48,12 @@ class NtpTest(test_utils.GlazierTestCase):
     request.assert_called_with(mock.ANY, 'time.google.com', version=3)
     eb.assert_has_calls([
         mock.call(
-            f'{constants.SYS_SYSTEM32}/cmd.exe', ['/c', 'date', '01-19-2016'],
+            os.path.join(constants.WINPE_SYSTEM32, 'cmd.exe'),
+            ['/c', 'date', '01-19-2016'],
             shell=True),
         mock.call(
-            f'{constants.SYS_SYSTEM32}/cmd.exe', ['/c', 'time', '16:23:50'],
+            os.path.join(constants.WINPE_SYSTEM32, 'cmd.exe'),
+            ['/c', 'time', '16:23:50'],
             shell=True)
     ])
 

--- a/glazier/lib/powershell_test.py
+++ b/glazier/lib/powershell_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for glazier.lib.powershell."""
 
+import os
 from unittest import mock
 
 from absl import flags
@@ -115,7 +116,8 @@ class PowershellTest(test_utils.GlazierTestCase):
     script_path = resource_dir.create_file(file_path='bin/script.ps1').full_path
     args = ['>>', 'out.txt']
     self.ps.RunResource('bin/script.ps1', args=args)
-    mock_runlocal.assert_called_with(self.ps, script_path, args, None)
+    mock_runlocal.assert_called_with(
+        self.ps, os.path.normpath(script_path), args, None)
 
     # Not Found
     with self.assert_raises_with_validation(powershell.InvalidPathError):


### PR DESCRIPTION
The Python test suite does not pass on Windows. Six modules assert POSIX-only behaviour, and `python_tests.yml` runs `ubuntu-latest` only, so none of it is visible in CI. No product code is changed.

Four are separator assumptions the diff makes obvious. `download_test` is subtler: it hardcodes the SHA256 of LF text, but `absltest.create_tempfile` opens `str` content in text mode, so the file reaches disk as CRLF. Passing bytes skips the translation.

`ntp_test` is two problems. `time.tzset()` does not exist on Windows, so the module raised `AttributeError` before any assertion ran. It also asserted `SYS_SYSTEM32` while `ntp.py` builds `BINARY` from `WINPE_SYSTEM32`. `SyncClockToNtp` runs only under `autobuild.py`'s `if winpe.check_winpe()` guard, so `WINPE_SYSTEM32` is correct and the assertion was wrong. The two constants collapse to one string under `posixpath`, which is why this never surfaced. Same root cause as #796.

Windows 11, Python 3.13.13: 56 passing / 3 failing before, 57 / 2 after. Counts come from `testing/run_tests.py` with `sys.executable` substituted for its PATH lookup of `python`, which is a separate issue and not part of this change. `splice_test` and `drivers_test` still fail; the first needs elevation to write `C:\Program Files\Splice`.
