### PR TITLE
Run the test modules with the interpreter running the test runner.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -33,7 +33,9 @@ def main():
                                           glazier.__name__ + '.'):
     if '_test' in test:
       print('**** %s ****\n' % test)
-      proc = subprocess.Popen(['python', '-m', test], stderr=subprocess.PIPE)
+      proc = subprocess.Popen(
+          [sys.executable, '-m', test], stderr=subprocess.PIPE
+      )
       _, err = proc.communicate()
       err = err.decode()
       print(err)


### PR DESCRIPTION
`run_tests.py` spawns each test module as `['python', '-m', test]`. That resolves `python` through PATH rather than using the interpreter running the runner. Inside a virtualenv that is not activated on PATH, every module is launched by the system interpreter instead, where the packages from `requirements.txt` are not installed, and all 59 modules fail with `ModuleNotFoundError: No module named 'absl'`.

`sys.executable` launches each module with the interpreter that already imported `glazier` to discover it.

Measured on Windows 11, Python 3.13.13, in a virtualenv built from `requirements.txt`. Before: `Success: 0` / `Failure: 59`. After: `Success: 51` / `Failure: 8`.

That this is interpreter resolution and not a broken environment: on the unpatched tree, running one module directly with the venv interpreter gives `Ran 15 tests ... OK`, while `subprocess.run(['python', ...])` from that same interpreter resolves to the system `python.exe` and raises the `ModuleNotFoundError` above.

CI does not hit this because `actions/setup-python` puts the target interpreter on PATH as `python`, making the two the same by construction. The failure is not platform specific, and a Linux virtualenv reproduces it.

The remaining 8 failures are pre-existing and unrelated. They only become observable once the modules import at all.
