### PR TITLE
Mock check_winpe in test_driver_wim and correct its call expectations.

### DIFF
--- a/glazier/lib/actions/drivers_test.py
+++ b/glazier/lib/actions/drivers_test.py
@@ -24,6 +24,7 @@ from glazier.lib.buildinfo import BuildInfo
 
 class DriversTest(test_utils.GlazierTestCase):
 
+  @mock.patch.object(drivers.winpe, 'check_winpe', autospec=True)
   @mock.patch.object(BuildInfo, 'ReleasePath')
   @mock.patch.object(BuildInfo, 'Branch')
   @mock.patch('glazier.lib.download.Download.VerifyShaHash', autospec=True)
@@ -32,7 +33,7 @@ class DriversTest(test_utils.GlazierTestCase):
   @mock.patch.object(drivers.file_util, 'CreateDirectories', autospec=True)
   def test_driver_wim(self, mock_createdirectories, mock_execute_binary,
                       mock_downloadfile, mock_verifyshahash, mock_branch,
-                      mock_releasepath):
+                      mock_releasepath, mock_check_winpe):
 
     bi = BuildInfo()
 
@@ -49,6 +50,7 @@ class DriversTest(test_utils.GlazierTestCase):
     }
     mock_branch.return_value = 'stable'
     mock_releasepath.return_value = '/'
+    mock_check_winpe.return_value = False
 
     # Success
     dw = drivers.DriverWIM(conf['data']['driver'], bi)
@@ -62,7 +64,7 @@ class DriversTest(test_utils.GlazierTestCase):
     cache = drivers.constants.SYS_CACHE
     mock_execute_binary.assert_has_calls([
         mock.call(
-            drivers.constants.WINPE_DISM,
+            drivers.constants.SYS_DISM,
             [
                 '/Mount-Image',
                 f'/ImageFile:{local}',
@@ -78,7 +80,7 @@ class DriversTest(test_utils.GlazierTestCase):
             shell=False,
         ),
         mock.call(
-            drivers.constants.WINPE_DISM,
+            drivers.constants.SYS_DISM,
             ['/Unmount-Image', f'/MountDir:{cache}\\Drivers\\', '/Discard'],
             shell=False,
         ),


### PR DESCRIPTION
`test_driver_wim` does not mock `winpe.check_winpe()`, so it reads the host registry and its outcome depends on the machine running it. On a non-WinPE host it fails.

The expected call list is also internally inconsistent: it pairs `WINPE_DISM` for mount and unmount with `SYS_PNPUTIL` for add-driver. `_ProcessWim` derives both from the same `lru_cache`-wrapped `check_winpe()`, so a run emits all-WinPE or all-SYS paths, never a mix.

This adds the mock returning `False` and corrects the two mount and unmount constants. `test_driver_wim_winpe` already covers the `True` branch with the same convention, so the two tests now cover one branch each.

`python_tests.yml` runs `ubuntu-latest` only, where `os.path.join(ROOT, os.sep, ...)` in `constants.py` discards the drive letter and `WINPE_DISM` equals `SYS_DISM`, which hides the inconsistency. That collapse is #796 and is not touched here.

Windows 11, Python 3.13.13, `python -m glazier.lib.actions.drivers_test`: before `Ran 10 tests` / `FAILED (failures=1)`, after `Ran 10 tests` / `OK`. Inverting the mock to `True` makes it fail again, so it still discriminates on the branch. No other module in the suite changes status.
