### PR TITLE
docs: fix copy-pasted description for Error Handling in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,8 +48,9 @@ supported syntax.
     configuration handler may call to perform a variety of tasks during imaging.
 *   [Policy Modules](policies.md) - Policy modules determine whether or not
     Autobuild should be allowed to proceed with an installation.
-*   [Error Handling](error_codes.md) - Policy modules determine whether or not
-    Autobuild should be allowed to proceed with an installation.
+*   [Error Handling](error_codes.md) - Glazier error codes are four digit
+    numbers (7XXX) attached to exceptions, giving users actionable feedback
+    about failures during imaging.
 *   [Config Handlers](./setup/config_handlers.md) - The Glazier configuration
     handling libraries are responsible for taking the configuration language as
     input, determining which commands apply to the current system, and executing


### PR DESCRIPTION
In `docs/README.md`, the **Error Handling** bullet reuses the exact description of the **Policy Modules** bullet right above it:

> \* [Policy Modules](policies.md) - Policy modules determine whether or not Autobuild should be allowed to proceed with an installation.
> \* [Error Handling](error_codes.md) - Policy modules determine whether or not Autobuild should be allowed to proceed with an installation.

This looks like a copy-paste leftover. The linked [error_codes.md](https://github.com/google/glazier/blob/master/docs/error_codes.md) actually documents Glazier's error code system (7XXX codes attached to exceptions for actionable feedback), so this PR replaces the description accordingly.

Docs-only change.